### PR TITLE
Refactors to move context manager to redpipe

### DIFF
--- a/redpipe/futures.py
+++ b/redpipe/futures.py
@@ -95,15 +95,14 @@ more examples or explanation.
 from .exceptions import ResultNotReady
 from json.encoder import JSONEncoder
 from functools import wraps
-from os import getenv
+from .system_stats import ENABLE_REDPIPE_STATS, threading_local
+
 
 __all__ = [
     'Future',
     'IS',
     'ISINSTANCE'
 ]
-
-ENABLE_REDPIPE_STATS = getenv('ENABLE_REDPIPE_STATS', 'false') == 'true'
 
 def IS(instance, other):  # noqa
     """
@@ -157,7 +156,6 @@ class Future(object):
         # Increment the global thread_local counter for futures created.
         try:
             if ENABLE_REDPIPE_STATS:
-                from system_stats import threading_local
                 threading_local.futures_created += 1
         except AttributeError:
             pass
@@ -190,7 +188,6 @@ class Future(object):
             # Increment the global thread_local counter for futures accessed.
             try:
                 if ENABLE_REDPIPE_STATS:
-                    from system_stats import threading_local
                     if res and id(res) not in threading_local.futures_accessed_ids:
                         threading_local.futures_accessed += 1
                         threading_local.futures_accessed_ids.append(id(res))

--- a/redpipe/futures.py
+++ b/redpipe/futures.py
@@ -190,7 +190,7 @@ class Future(object):
                 if ENABLE_REDPIPE_STATS:
                     if res and id(res) not in threading_local.futures_accessed_ids:
                         threading_local.futures_accessed += 1
-                        threading_local.futures_accessed_ids.append(id(res))
+                        threading_local.futures_accessed_ids.add(id(res))
             except AttributeError:
                 pass
 

--- a/redpipe/system_stats.py
+++ b/redpipe/system_stats.py
@@ -1,0 +1,34 @@
+import threading
+from os import getenv
+from contextlib import contextmanager
+
+
+
+ENABLE_REDPIPE_STATS = getenv('ENABLE_REDPIPE_STATS', 'false') == 'true'
+
+threading_local = threading.local()
+threading_local.futures_accessed = 0
+threading_local.futures_created = 0
+threading_local.futures_accessed_ids = []
+@contextmanager
+def log_redpipe_stats(name: str, logger, pid):
+    """
+    Resets futures created and accessed counts before a function is called and then measures those values to report after
+    """
+    if not ENABLE_REDPIPE_STATS:
+        yield
+    else:
+        threading_local.futures_accessed = 0
+        threading_local.futures_created = 0
+        threading_local.futures_accessed_ids = []
+        yield
+        consumed = threading_local.futures_accessed / threading_local.futures_created \
+            if threading_local.futures_created != 0 else 0
+        logging_data = {
+            "pid": pid,
+            "name": name,
+            "futures_accessed": threading_local.futures_accessed,
+            "futures_created": threading_local.futures_created,
+            "Consumption Percentage": "{:.0%}".format(consumed)
+        }
+        logger.info("REDPIPE_STATS", **logging_data)

--- a/redpipe/system_stats.py
+++ b/redpipe/system_stats.py
@@ -9,7 +9,7 @@ ENABLE_REDPIPE_STATS = getenv('ENABLE_REDPIPE_STATS', 'false') == 'true'
 threading_local = threading.local()
 threading_local.futures_accessed = 0
 threading_local.futures_created = 0
-threading_local.futures_accessed_ids = []
+threading_local.futures_accessed_ids = set()
 @contextmanager
 def log_redpipe_stats(name: str, logger, pid):
     """
@@ -20,7 +20,7 @@ def log_redpipe_stats(name: str, logger, pid):
     else:
         threading_local.futures_accessed = 0
         threading_local.futures_created = 0
-        threading_local.futures_accessed_ids = []
+        threading_local.futures_accessed_ids = set()
         yield
         consumed = threading_local.futures_accessed / threading_local.futures_created \
             if threading_local.futures_created != 0 else 0


### PR DESCRIPTION
Taking the context manager from backend and moving it to redpipe to have complete separation of concern and also avoid having modules reaching outside of their immediate context.