### PR TITLE
fix a mypy error; update mypy & flake8; drop python 3.7 and 3.8 support

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 coverage >= 3.7.1
 importlib_metadata<5
-flake8
-mypy
+flake8==7.1.0
+mypy==1.10.1
 coveralls
 types-redis
 redislite>=3.0.271

--- a/redpipe/keyspaces.py
+++ b/redpipe/keyspaces.py
@@ -1505,7 +1505,7 @@ class SortedSet(Keyspace):
 
     def zadd(self,
              name: str,
-             members: Union[str, typing.List[str], dict],
+             members: Union[str, typing.List[str], dict, Future],
              score: float = 1.0,
              nx: bool = False,
              xx: bool = False,
@@ -1547,7 +1547,7 @@ class SortedSet(Keyspace):
             for member in members:
                 _args += [str(score), self.valueparse.encode(member)]
         else:
-            _args += [str(score), self.valueparse.encode(members)]
+            _args += [str(score), self.valueparse.encode(str(members))]
 
         if nx and xx:
             raise InvalidOperation('cannot specify nx and xx at the same time')

--- a/setup.sh
+++ b/setup.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
 
-command -v virtualenv >/dev/null 2>&1 || { echo >&2 "I require virtualenv but it's not installed.  Aborting."; exit 1; }
-
 root_dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 venv_dir="$root_dir/.venv"
 
-
 if [ ! -f "$venv_dir/bin/python" ]
 then
     echo "configuring virtualenv $venv_dir ..."
-    virtualenv -q "$venv_dir" || { echo >&2 "unable to configure the virtualenv for the project in $venv_dir"; exit 1; }
+    python -m venv "$venv_dir" || { echo >&2 "unable to configure the virtualenv for the project in $venv_dir"; exit 1; }
 fi
 
 "$venv_dir/bin/python" -m pip install --upgrade pip
@@ -20,7 +17,7 @@ then
     exit 1
 fi
 
-"$venv_dir/bin/pip" install -q -r "$root_dir/dev-requirements.txt"
+"$venv_dir/bin/pip" install -q -r "$root_dir/local-dev-requirements.txt"
 
 if [ $? -ne 0 ]
 then
@@ -28,3 +25,4 @@ then
     exit 1
 fi
 
+source "$venv_dir/bin/activate"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = {p37,p38,p39}-{plain,hiredis}, lint
+envlist = {p39}-{plain,hiredis}, lint
 
 [testenv]
 deps =
@@ -17,8 +17,8 @@ commands = python {envbindir}/coverage run --source redpipe -p test.py
 [testenv:lint]
 basepython= python3.9
 deps =
-    flake8==3.8.4
-    mypy==0.991
+    flake8==7.1.0
+    mypy==1.10.1
 commands = flake8 \
              --exclude="./build,.venv*,.tox,dist" \
              {posargs}


### PR DESCRIPTION
Realized I hadn't run `make tox` from scratch prior to #5 ; fixing a `mypy` typing error and also doing some additional modernization (dropping python 3.7 and 3.8, using `venv` instead of `virtualenv`, & updating some dependencies).