### PR TITLE
improve support for cluster mode

### DIFF
--- a/redpipe/__init__.py
+++ b/redpipe/__init__.py
@@ -94,3 +94,4 @@ from .exceptions import *  # noqa
 from .futures import *  # noqa
 from .tasks import *  # noqa
 from .scripts import *  # noqa
+from .redis_cluster import *  # noqa

--- a/redpipe/connections.py
+++ b/redpipe/connections.py
@@ -56,7 +56,7 @@ class ConnectionManager(object):
             raise InvalidPipeline('%s is not configured' % name)
 
     @classmethod
-    def get_client(cls, name: Optional[str]) -> redis.Redis:
+    def get_client(cls, name: str) -> redis.Redis:
         """
         Returns a low-level Redis client for the connection
         Called by the redpipe.scripts module.

--- a/redpipe/redis_cluster.py
+++ b/redpipe/redis_cluster.py
@@ -1,0 +1,63 @@
+import redis
+import redis.commands
+import redis.cluster
+from typing import Optional, Union, Awaitable, Any
+
+
+class CustomClusterPipeline(redis.cluster.ClusterPipeline):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cluster_response_callbacks['SCAN'] = self.intercept_scan_results
+
+    def scan(self, cursor: int = 0, match: Optional[str] = None,
+             count: Optional[int] = None, **kwargs) -> Union[Awaitable, Any]:
+        options = kwargs.copy()
+        shard_idx = cursor >> 48
+        cursor = cursor & 0xffffffffffff
+        options['shard_idx'] = shard_idx
+
+        # TODO: would be nice to be able to specify reading from replicas
+        node = self.get_sorted_primaries()[shard_idx]
+
+        # skip the "blocked" parent method for scan()
+        return super(redis.cluster.ClusterPipeline, self).scan(
+            cursor, match, count, **options)
+
+    def intercept_scan_results(self, result, **kwargs):
+        (new_cursor, keys) = result
+        nodes = self.get_sorted_primaries()
+        shard_idx = kwargs.pop('shard_idx')
+        if new_cursor == 0:
+            shard_idx += 1
+        if shard_idx < len(nodes):
+            new_cursor = (shard_idx << 48) | new_cursor
+
+        return new_cursor, keys
+
+    def get_sorted_primaries(self):
+        return sorted(self.get_primaries(), key=lambda n: n.name)
+
+
+class CustomRedisCluster(redis.RedisCluster):
+    @classmethod
+    def from_url(cls, url, **kwargs):
+        """
+        Return a Redis client object configured from the given URL
+        """
+        return cls(url=url, **kwargs)
+
+    def __init__(self, *args, **kwargs,):
+        super().__init__(*args, **kwargs)
+
+    def pipeline(self, transaction=None, shard_hint=None):
+        return CustomClusterPipeline(
+            nodes_manager=self.nodes_manager,
+            commands_parser=self.commands_parser,
+            startup_nodes=self.nodes_manager.startup_nodes,
+            result_callbacks=self.result_callbacks,
+            cluster_response_callbacks=self.cluster_response_callbacks,
+            cluster_error_retry_attempts=self.cluster_error_retry_attempts,
+            read_from_replicas=self.read_from_replicas,
+            reinitialize_steps=self.reinitialize_steps,
+            lock=self._lock,
+        )

--- a/redpipe/redis_cluster.py
+++ b/redpipe/redis_cluster.py
@@ -2,6 +2,10 @@ import redis
 import redis.commands
 import redis.cluster
 from typing import Optional, Union, Awaitable, Any
+from typing_extensions import TypeAlias
+
+
+KeyType: TypeAlias = Union[bytes, str, memoryview]
 
 
 class CustomClusterPipeline(redis.cluster.ClusterPipeline):
@@ -9,8 +13,11 @@ class CustomClusterPipeline(redis.cluster.ClusterPipeline):
         super().__init__(*args, **kwargs)
         self.cluster_response_callbacks['SCAN'] = self.intercept_scan_results
 
-    def scan(self, cursor: int = 0, match: Optional[str] = None,
-             count: Optional[int] = None, **kwargs) -> Union[Awaitable, Any]:
+    def scan(self, cursor: int = 0,
+             match: Union[KeyType, None] = None,
+             count: Optional[int] = None,
+             _type: Optional[str] = None,  # for lint/type-checking purposes
+             **kwargs) -> Union[Awaitable, Any]:
         shard_idx = cursor >> 48
         cursor = cursor & 0xffffffffffff
 

--- a/redpipe/scripts.py
+++ b/redpipe/scripts.py
@@ -38,7 +38,13 @@ def register_smart_script(conn_name, code, use_evalsha_cb):
     @param use_evalsha_cb: function - no args, returns True if EVALSHA should
                                         be used, False if EVAL should be used.
     """
-    pipe = ConnectionManager.get(conn_name)
-    pipe.script_load(code)
-    sha = pipe.execute(raise_on_error=True)[0]
+    client = ConnectionManager.get_client(conn_name)
+    if client is None:
+        # if no low-level client was passed in, then we'll try a pipeline; but
+        # this will fail if it's a ClusterPipeline
+        pipe = ConnectionManager.get(conn_name)
+        pipe.script_load(code)
+        sha = pipe.execute(raise_on_error=True)[0]
+    else:
+        sha = client.script_load(code)
     return SmartScript(code, sha, use_evalsha_cb)

--- a/redpipe/scripts.py
+++ b/redpipe/scripts.py
@@ -13,9 +13,6 @@ class SmartScript(object):
     EVALSHA dynamically
     """
 
-    CMD_EVAL = "eval"
-    CMD_EVALSHA = "evalsha"
-
     def __init__(self, code, sha, use_evalsha_cb=None):
         self.code = code
         self.sha = sha

--- a/test.py
+++ b/test.py
@@ -1321,7 +1321,8 @@ class MultiNodeRedisClusterTestCase(unittest.TestCase):
         redpipe.reset()
 
     def tearDown(self):
-        self.r.flushall()
+        for node in type(self).c.nodes:
+            node.client.flushall()
 
     def test_basic(self):
         with redpipe.autoexec() as pipe:

--- a/test.py
+++ b/test.py
@@ -11,9 +11,13 @@ import redis
 import redislite  # type: ignore
 import redpipe
 import redpipe.tasks
+from redpipe.redis_cluster import CustomRedisCluster
 
 # Tegalu: I can eat glass ...
 utf8_sample = u'నేను గాజు తినగలను మరియు అలా చేసినా నాకు ఏమి ఇబ్బంది లేదు'
+
+
+NUM_HASH_SLOTS = 16384
 
 
 class StaticEvalShaController(object):
@@ -30,10 +34,12 @@ class StaticEvalShaController(object):
         return self._use_evalsha
 
 
-class SingleNodeRedisCluster(object):
+class RedisClusterNode(object):
     __slots__ = ['node', 'port', 'client']
 
-    def __init__(self, starting_port=7000):
+    def __init__(self, starting_port=7000, slot_range=None):
+        if slot_range is None:
+            slot_range = range(0, NUM_HASH_SLOTS)
         port = starting_port
         while port < 55535:
 
@@ -52,7 +58,7 @@ class SingleNodeRedisCluster(object):
                 'port': port
             }
         )
-        self.node.execute_command('CLUSTER ADDSLOTS', *range(0, 16384))
+        self.node.execute_command('CLUSTER ADDSLOTS', *slot_range)
         for i in range(0, 100):
             try:
                 self.node.set('__test__', '1')
@@ -63,7 +69,7 @@ class SingleNodeRedisCluster(object):
 
             time.sleep(0.1)
 
-        self.client = redis.RedisCluster.from_url(
+        self.client = CustomRedisCluster.from_url(
             'redis://127.0.0.1:%d' % port)
 
     @staticmethod
@@ -87,6 +93,52 @@ class SingleNodeRedisCluster(object):
 
     def __del__(self):
         self.shutdown()
+
+    def url(self):
+        return f"redis://127.0.0.1:{self.port}"
+
+
+class MockRedisCluster(object):
+    def __init__(self, num_nodes=1):
+        if NUM_HASH_SLOTS % num_nodes != 0:
+            raise ValueError(f'num_nodes must divide into {NUM_HASH_SLOTS}')
+        slot_incr = NUM_HASH_SLOTS // num_nodes
+        self.nodes = []
+        starting_port = 7000
+        for i in range(0, num_nodes):
+            slot_start = i * slot_incr
+            slot_end = slot_start + slot_incr
+            slot_range = range(slot_start, slot_end)
+            node = RedisClusterNode(starting_port, slot_range)
+            self.nodes.append(node)
+            starting_port = node.port + 1
+
+        first_node = self.nodes[0]
+        self.client = first_node.client
+
+        if len(self.nodes) > 1:
+            for i in range(1, num_nodes):
+                node = self.nodes[i]
+                first_node.client.cluster_meet('127.0.0.1', node.port)
+
+            # give nodes time to meet each other and form the cluster
+            remaining_attempts = 10
+            while remaining_attempts > 0:
+                print('sleeping 1 sec to let nodes meet...')
+                time.sleep(1)
+
+                if all(all(other_node['connected'] for other_node
+                           in node.client.cluster_nodes().values())
+                       for node in self.nodes):
+                    return
+
+                remaining_attempts -= 1
+
+            raise Exception("cluster failed to form!")
+
+    def shutdown(self):
+        for node in self.nodes:
+            node.shutdown()
 
 
 class BaseTestCase(unittest.TestCase):
@@ -1156,7 +1208,7 @@ class ConnectTestCase(unittest.TestCase):
 class RedisClusterTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.c = SingleNodeRedisCluster()
+        cls.c = MockRedisCluster()
         cls.r = cls.c.client
         redpipe.connect_redis(cls.r)
 
@@ -1173,8 +1225,10 @@ class RedisClusterTestCase(unittest.TestCase):
     def test_basic(self):
         with redpipe.autoexec() as pipe:
             pipe.set('foo', 'bar')
-            res = pipe.get('foo')
-        self.assertEqual(res, b'bar')
+            scan_res = pipe.scan(0, match='*', count=100)
+            get_res = pipe.get('foo')
+        self.assertEqual(scan_res, (0, [b'foo']))
+        self.assertEqual(get_res, b'bar')
 
     def test_list(self):
         class Test(redpipe.List):
@@ -1250,6 +1304,70 @@ class RedisClusterTestCase(unittest.TestCase):
 
         self.assertEqual(pfadd, 1)
         self.assertEqual(pfcount, 4)
+
+
+class MultiNodeRedisClusterTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.c = MockRedisCluster(num_nodes=2)
+        cls.r = CustomRedisCluster.from_url(cls.c.nodes[0].url())
+        redpipe.connect_redis(cls.r)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r = None
+        cls.c.shutdown()
+        cls.c = None
+        redpipe.reset()
+
+    def tearDown(self):
+        self.r.flushall()
+
+    def test_basic(self):
+        with redpipe.autoexec() as pipe:
+            pipe.set('foo1', 'bar1')
+            pipe.set('foo2', 'bar2')
+            get1_res = pipe.get('foo1')  # foo1 hashes to slot 13431 (node 1)
+            get2_res = pipe.get('foo2')  # foo2 hashes to slot 1044 (node 0)
+
+        self.assertEqual(get1_res, b'bar1')
+        self.assertEqual(get2_res, b'bar2')
+
+    def test_scan(self):
+        all_keys = {
+            'foo1',  # foo1 hashes to slot 13431 (node 1)
+            'foo2',  # foo2 hashes to slot 1044 (node 0)
+            'foo3',  # foo3 hashes to slot 5173 (node 0)
+            'foo4',  # foo4 hashes to slot 9426 (node 1)
+        }
+        all_keys_binary = {k.encode('utf-8') for k in all_keys}
+        with redpipe.autoexec() as pipe:
+            for key in all_keys:
+                pipe.set(key, f'{key}_value')
+
+        collected_keys = []
+        cursor = 0
+        have_exhausted_first_node = False
+
+        total_scan_calls = 0  # just a safeguard to prevent us spinning forever
+        while total_scan_calls < 100:
+            total_scan_calls += 1
+            with redpipe.autoexec() as pipe:
+                scan_result = pipe.scan(cursor=cursor, match='*', count=1)
+            cursor, keys = scan_result
+            collected_keys.extend(keys)
+            if cursor == 0:
+                # shouldn't finish until we've crossed a node boundary
+                self.assertTrue(have_exhausted_first_node)
+                # should have scanned all keys
+                self.assertEqual(set(collected_keys), all_keys_binary)
+                break
+            if cursor == 1 << 48:
+                # should only have scanned the keys that hash to node 0
+                self.assertEqual(set(collected_keys), {b'foo2', b'foo3'})
+                have_exhausted_first_node = True
+
+        self.assertLess(total_scan_calls, 100, "too many scan iterations!")
 
 
 class StrictStringTestCase(BaseTestCase):


### PR DESCRIPTION
Various improvements that will allow MP to use `redpipe` against a cluster-mode Redis service (e.g. MemoryDB).  These have been tested against our codebase via unit tests a while back; just trying to get them onto `master`.

- bypass unnecessarily blocked commands in cluster mode
- execute `SCRIPT LOAD` calls directly via the redis client instead of a pipeline
- implement custom RedisCluster client implementation that supports `SCAN` by including sorted node index in high-order bits of cursors (similar to what RLEC does)
