### PR TITLE
bump flake8 7.3.0 and mypy 1.19.1 (2026Q2 dep update)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ RedPipe is a Python library that provides a wrapper around Redis pipelines (redi
 ### Linting and Type Checking
 - `flake8 --exclude="./build,.venv*,.tox,dist"` - Code linting (configured in tox.ini)
 - `mypy redpipe test.py` - Type checking
-- Flake8 version: 7.1.0, MyPy version: 1.10.1
+- Flake8 version: 7.3.0, MyPy version: 1.19.1
 
 ### Documentation
 - `make documentation` - Build Sphinx documentation

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 coverage >= 3.7.1
 importlib_metadata
-flake8==7.1.0
-mypy==1.10.1
+flake8==7.3.0
+mypy==1.19.1
 coveralls
 types-redis
 redislite>=3.0.271

--- a/redpipe/connections.py
+++ b/redpipe/connections.py
@@ -14,12 +14,13 @@ These functions are all you will need to call from your code:
 
 Everything else is for internal use.
 """
+import sys
 import redis
 from typing import (Optional, Callable, Dict, Union)
-try:
-    from typing import TypeAlias  # Python 3.10+
-except ImportError:
-    from typing_extensions import TypeAlias  # Python 3.9 and below
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 from .exceptions import AlreadyConnected, InvalidPipeline
 
 __all__ = [

--- a/redpipe/redis_cluster.py
+++ b/redpipe/redis_cluster.py
@@ -1,11 +1,12 @@
+import sys
 import redis
 import redis.commands
 import redis.cluster
 from typing import Optional, Union, Awaitable, Any
-try:
-    from typing import TypeAlias  # Python 3.10+
-except ImportError:
-    from typing_extensions import TypeAlias  # Python 3.9 and below
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 
 KeyType: TypeAlias = Union[bytes, str, memoryview]

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ commands = python {envbindir}/coverage run --source redpipe -p test.py
 [testenv:lint]
 basepython= python3.9
 deps =
-    flake8==7.1.0
-    mypy==1.10.1
+    flake8==7.3.0
+    mypy==1.19.1
 commands = flake8 \
              --exclude="./build,.venv*,.tox,dist" \
              {posargs}


### PR DESCRIPTION
## 🚀 Notes for Reviewers
Quarterly dependency refresh — bumps the two outdated pinned dev-only tools. No changes to `install_requires`.

Mypy 1.19.1 rejects the old `try/except ImportError` fallback for `typing.TypeAlias` on Python 3.9, so swapped it for a `sys.version_info >= (3, 10)` check that mypy narrows correctly. Runtime behavior is identical.

## 🔗 Asana Tasks
Update redpipe dependencies (2026Q2)

## 🧪 Extended Description

### What changed
- `dev-requirements.txt`: `flake8==7.1.0` → `7.3.0`, `mypy==1.10.1` → `1.19.1`
- `tox.ini` (lint env): same two bumps
- `redpipe/connections.py`, `redpipe/redis_cluster.py`: `TypeAlias` import guarded by `sys.version_info` instead of `try/except ImportError`
- Project docs: tool version references updated to match

### Validation
- `tox -e lint` → clean (flake8 + mypy across 15 source files)
- `tox -e p39-plain`, `p39-hiredis`, `p310-plain` → no new failures vs. master